### PR TITLE
Add Google Photos upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,16 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Google Photos Integration
+
+Set the following environment variables to enable uploading recognition images to Google Photos:
+
+- `GOOGLE_PHOTOS_CLIENT_ID`
+- `GOOGLE_PHOTOS_CLIENT_SECRET`
+- `GOOGLE_PHOTOS_REFRESH_TOKEN`
+
+These credentials come from an OAuth 2.0 client with access to the Photos Library API. Create a `.env.local` file locally or configure them in your deployment platform.
+
+Images are sent to the `/api/upload-photos` endpoint which uploads the screenshot to your Google Photos library and optionally into the album specified by the request.
+

--- a/app/api/upload-photos/route.ts
+++ b/app/api/upload-photos/route.ts
@@ -1,0 +1,66 @@
+import { google } from 'googleapis';
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    if (!body.image) {
+      return NextResponse.json({ error: 'No image data provided' }, { status: 400 });
+    }
+
+    const base64Data = body.image.replace(/^data:image\/\w+;base64,/, '');
+    const imageBuffer = Buffer.from(base64Data, 'base64');
+    const filename = body.metadata?.filename || `upload_${Date.now()}.jpg`;
+
+    const oauth2Client = new google.auth.OAuth2(
+      process.env.GOOGLE_PHOTOS_CLIENT_ID,
+      process.env.GOOGLE_PHOTOS_CLIENT_SECRET
+    );
+    oauth2Client.setCredentials({ refresh_token: process.env.GOOGLE_PHOTOS_REFRESH_TOKEN });
+    const tokenResponse = await oauth2Client.getAccessToken();
+    const accessToken = tokenResponse?.token;
+    if (!accessToken) {
+      return NextResponse.json({ error: 'Failed to obtain access token' }, { status: 500 });
+    }
+
+    const uploadResponse = await fetch('https://photoslibrary.googleapis.com/v1/uploads', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-type': 'application/octet-stream',
+        'X-Goog-Upload-File-Name': filename,
+        'X-Goog-Upload-Protocol': 'raw'
+      },
+      body: imageBuffer
+    });
+
+    const uploadToken = await uploadResponse.text();
+    if (!uploadResponse.ok) {
+      throw new Error(uploadToken);
+    }
+
+    const createResponse = await fetch('https://photoslibrary.googleapis.com/v1/mediaItems:batchCreate', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        albumId: body.metadata?.albumId,
+        newMediaItems: [
+          { simpleMediaItem: { uploadToken, fileName: filename } }
+        ]
+      })
+    });
+
+    const createResult = await createResponse.json();
+    if (!createResponse.ok) {
+      throw new Error(createResult.error?.message || 'Failed to create media item');
+    }
+
+    return NextResponse.json({ success: true, result: createResult });
+  } catch (err: any) {
+    console.error('Google Photos upload error:', err);
+    return NextResponse.json({ error: err.message }, { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,7 +53,7 @@ export default function RecognitionForm() {
       const imageData = canvas.toDataURL('image/jpeg', 0.95);
       const filename = `ATL_Recognition_${new Date().toLocaleDateString('en-US').replace(/\//g, '-')}_${new Date().getTime()}.jpg`;
 
-       const response = await fetch('/api/upload', {
+       const response = await fetch('/api/upload-photos', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- add a new `/api/upload-photos` endpoint that uploads screenshots to Google Photos
- update the form to POST screenshots to this endpoint
- document Google Photos setup and new environment variables
- read filename and albumId from `metadata`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `node node_modules/next/dist/bin/next lint` *(fails: Cannot find module 'next/dist/bin/next')*

------
https://chatgpt.com/codex/tasks/task_e_68504e3bee208321b3793e9ad90a6a3c